### PR TITLE
Added debug message to log how much time passes before a predicate happens

### DIFF
--- a/py/strato/whiteboxtest/infra/suite.py
+++ b/py/strato/whiteboxtest/infra/suite.py
@@ -84,6 +84,8 @@ def TS_ASSERT_PREDICATE_TIMEOUT(predicate, * args, ** kwargs):
         try:
             if predicate(* args, ** kwargs):
                 _successful_TS_ASSERT_Count += 1
+                logging.debug("Done waiting for predicate %s after %s secs",
+                              predicate, str(time.time() - before))
                 return
             else:
                 time.sleep(interval)
@@ -91,6 +93,7 @@ def TS_ASSERT_PREDICATE_TIMEOUT(predicate, * args, ** kwargs):
             time.sleep(interval)
     if predicate(* args, ** kwargs):
         _successful_TS_ASSERT_Count += 1
+        logging.debug("Predicate %s succeed after timeout expired", predicate)
         return
     else:
         raiseAssert("TS_ASSERT_PREDICATE_TIMEOUT failed: %s" % predicate)


### PR DESCRIPTION
This will help us to detect when test is timed out if it is an unusual timeout or if normally the timeout almost reached, thus need to be extended.
Do you see any harm with this ? is debug level good enough or should it be info ?